### PR TITLE
Non RFC1918 compliant ip address handling

### DIFF
--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -45,6 +45,11 @@ properties:
   ##      on the clustered Vault backend.  Sensible defaults
   ##      with suitable auto-generation.
   ##
+  safe.peer.force_bind_default_ip:
+    description: |
+      Forces Consul agent to bind to the default ip address, necessary when using non
+      RFC1918 space in a private context.
+      default: false
 
   safe.peer.port:
     description: TCP port to use for peer-to-peer communication

--- a/jobs/vault/templates/config/consul.conf
+++ b/jobs/vault/templates/config/consul.conf
@@ -16,11 +16,10 @@
   "datacenter":         "vault",
   "leave_on_terminate": true,
   "server":             true,
-
   "start_join":       <%= p('safe.cluster_ips', []).to_json %>,
   "retry_join":       <%= p('safe.cluster_ips', []).to_json %>,
   "bootstrap_expect": <%= p('safe.cluster_ips', []).size %>,
-
+  <%=  p('safe.peer.force_bind_default_ip') ? "\"bind_addr\": \"#{spec.ip}\"," : "" %>
   "verify_incoming":  false,
   "verify_outgoing":  <% if p('safe.peer.tls.verify') %>true<% else %>false<% end %>,
   "ca_file":          "/var/vcap/jobs/vault/tls/peer/ca.pem",


### PR DESCRIPTION
A handful of very large organizations allocate public ip space for use
in their private environments. Consul refuses to bind to a Non RFC1918
address by default and bind_addr needs to be set in the config.