### PR TITLE
upgrade consul to 0.7.1 to support snapshots

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,6 @@
-consul/consul_0.7.0_linux_amd64.zip:
-  size: 6470848
-  object_id: 542a845e-a01e-4742-a01a-a6be315847d2
-  sha: 32d5f51c35b75216cf73cabe0329239355dc4266
+consul/consul_0.7.1_linux_amd64.zip:
+  size: 7359222
+  sha: c2be9eebc40bf552e260c7dd31a77cb60474712f
 strongbox/strongbox:
   size: 6420275
   object_id: 44281efb-8fa1-4be6-b375-26500640aef8

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eu
 
-VERSION=0.7.0
-# from https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_linux_amd64.zip
+VERSION=0.7.1
+# from https://releases.hashicorp.com/consul/0.7.1/consul_0.7.1_linux_amd64.zip
 cd consul
 unzip consul_${VERSION}_linux_amd64.zip
 mkdir -p  ${BOSH_INSTALL_TARGET}/bin

--- a/packages/consul/spec
+++ b/packages/consul/spec
@@ -2,4 +2,4 @@
 name: consul
 dependencies: []
 files:
-  - consul/consul_0.7.0_linux_amd64.zip
+  - consul/consul_0.7.1_linux_amd64.zip


### PR DESCRIPTION
This adds the support for command "consul snapshot save ..." and "consul snapshot restore ..."

I have another PR incoming that implements bbr using this mechanism. 
Please upload https://releases.hashicorp.com/consul/0.7.1/consul_0.7.1_linux_amd64.zip in your S3 store so that this release can use it before you accept this PR.
