### PR TITLE
Add a property for setting whether a certificate is self signed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'bosh-template'
+  gem 'rspec'
+  gem 'rspec-its'
+  gem 'guard-rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,69 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bosh-template (2.3.0)
+      semi_semantic (~> 1.2.0)
+    coderay (1.1.2)
+    diff-lcs (1.5.0)
+    ffi (1.15.5)
+    formatador (0.3.0)
+    guard (2.18.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    lumberjack (1.2.8)
+    method_source (1.0.0)
+    nenv (0.3.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rb-fsevent (0.11.1)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    semi_semantic (1.2.0)
+    shellany (0.0.1)
+    thor (1.2.1)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  bosh-template
+  guard-rspec
+  rspec
+  rspec-its
+
+BUNDLED WITH
+   2.2.33

--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -73,6 +73,10 @@ properties:
     description: Verify the TLS certificates presented by the Consul backend
     default: true
 
+  safe.peer.tls.self_signed:
+    description: Indicate whether the certificates are self signed
+    default: false
+
   safe.ui:
     description: If set to true, the Vault UI will be enabled.
     default: false

--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -10,6 +10,7 @@ templates:
   bin/vault: bin/vault
   bin/consul: bin/consul
   bin/strongbox: bin/strongbox
+  bin/pre-start: bin/pre-start
 
   config/vault.conf: config/vault.config
   config/consul.conf: config/consul.json
@@ -72,10 +73,6 @@ properties:
   safe.peer.tls.verify:
     description: Verify the TLS certificates presented by the Consul backend
     default: true
-
-  safe.peer.tls.self_signed:
-    description: Indicate whether the certificates are self signed
-    default: false
 
   safe.ui:
     description: If set to true, the Vault UI will be enabled.

--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -74,6 +74,10 @@ properties:
     description: Verify the TLS certificates presented by the Consul backend
     default: true
 
+  safe.peer.tls.use_self_signed_certs:
+    description: Indicate whether we generate self-signed peer certificates
+    default: false
+
   safe.ui:
     description: If set to true, the Vault UI will be enabled.
     default: false

--- a/jobs/vault/templates/bin/consul
+++ b/jobs/vault/templates/bin/consul
@@ -27,13 +27,6 @@ case $1 in
     mkdir -p ${DAT_DIR}/consul
     chown vcap:vcap ${DAT_DIR}/consul
 
-    # check for certificates
-    if ! (openssl x509 -noout -in ${JOB_DIR}/tls/peer/ca.pem   && \
-          openssl x509 -noout -in ${JOB_DIR}/tls/peer/cert.pem && \
-          openssl rsa  -noout -in ${JOB_DIR}/tls/peer/key.pem); then
-      /var/vcap/packages/certifier/bin/certify ${JOB_DIR}/tls/peer/
-    fi
-
     # run consul
     GOMAXPROCS=2 \
     chpst -u vcap:vcap \

--- a/jobs/vault/templates/bin/pre-start
+++ b/jobs/vault/templates/bin/pre-start
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu
+
+# If are no supplied certificates generate self signed certificates
+
+VAULT_JOB_DIR=/var/vcap/jobs/vault
+CONSUL_JOB_DIR=/var/vcap/jobs/consul
+
+ # check for vault certificates
+if ! (openssl x509 -noout -in ${VAULT_JOB_DIR}/tls/vault/cert.pem &&
+      openssl rsa  -noout -in ${VAULT_JOB_DIR}/tls/vault/key.pem); then
+  /var/vcap/packages/certifier/bin/certify ${VAULT_JOB_DIR}/tls/vault/
+fi
+
+# check for consul certificates
+if ! (openssl x509 -noout -in ${CONSUL_JOB_DIR}/tls/peer/ca.pem   && \
+      openssl x509 -noout -in ${CONSUL_JOB_DIR}/tls/peer/cert.pem && \
+      openssl rsa  -noout -in ${CONSUL_JOB_DIR}/tls/peer/key.pem); then
+  /var/vcap/packages/certifier/bin/certify ${CONSUL_JOB_DIR}/tls/peer/
+fi

--- a/jobs/vault/templates/bin/vault
+++ b/jobs/vault/templates/bin/vault
@@ -18,12 +18,6 @@ case $1 in
       rm -f $PIDFILE
     fi
 
-    # check for certificates
-    if ! (openssl x509 -noout -in ${JOB_DIR}/tls/vault/cert.pem &&
-          openssl rsa  -noout -in ${JOB_DIR}/tls/vault/key.pem); then
-      /var/vcap/packages/certifier/bin/certify ${JOB_DIR}/tls/vault/
-    fi
-
     bin=$(readlink -nf /var/vcap/packages/vault/bin/vault)
     setcap cap_ipc_lock=+ep         $bin
     setcap cap_net_bind_service=+ep $bin

--- a/jobs/vault/templates/config/vault.conf
+++ b/jobs/vault/templates/config/vault.conf
@@ -8,8 +8,10 @@ backend "consul" {
   tls_min_version = "tls12"
   tls_skip_verify = "<% if p('safe.peer.tls.verify') %>false<% else %>true<% end %>"
   tls_ca_file     = "/var/vcap/jobs/vault/tls/peer/ca.pem"
+  <%- if ! p('safe.peer.tls.use_self_signed_certs') -%>
   tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"
   tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"
+  <%- end -%>
 }
 
 listener "tcp" {

--- a/jobs/vault/templates/config/vault.conf
+++ b/jobs/vault/templates/config/vault.conf
@@ -8,10 +8,8 @@ backend "consul" {
   tls_min_version = "tls12"
   tls_skip_verify = "<% if p('safe.peer.tls.verify') %>false<% else %>true<% end %>"
   tls_ca_file     = "/var/vcap/jobs/vault/tls/peer/ca.pem"
-  <%- if ! p('safe.peer.tls.self_signed') -%>
   tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"
   tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"
-  <%- end -%>
 }
 
 listener "tcp" {

--- a/jobs/vault/templates/config/vault.conf
+++ b/jobs/vault/templates/config/vault.conf
@@ -8,8 +8,10 @@ backend "consul" {
   tls_min_version = "tls12"
   tls_skip_verify = "<% if p('safe.peer.tls.verify') %>false<% else %>true<% end %>"
   tls_ca_file     = "/var/vcap/jobs/vault/tls/peer/ca.pem"
+  <%- if ! p('safe.peer.tls.self_signed') -%>
   tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"
   tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"
+  <%- end -%>
 }
 
 listener "tcp" {

--- a/spec/jobs/consul_spec.rb
+++ b/spec/jobs/consul_spec.rb
@@ -30,49 +30,7 @@ describe 'consul' do
         rendered_template = JSON.parse(template.render(properties, consumes: links))
 
         expect(rendered_template['datacenter']).to eq('vault')
-        # expect(rendered_template).to include('tls_cert_file   = "/var/vcap/jobs/consul/tls/peer/cert.pem"')
-        # expect(rendered_template).to include('tls_key_file    = "/var/vcap/jobs/consul/tls/peer/key.pem"')
-        # expect(rendered_template).to include('address = "0.0.0.0:443"')
-        # expect(rendered_template).to include('ui = false')
-        # expect(rendered_template).to include('api_addr = "https://192.168.0.0:443"')
       end
     end
-
-    # context 'with tls settings' do
-    #   context 'safe.peer.tls.verify = false' do
-    #     it 'skips ssl verification' do
-    #       properties.merge!({
-    #         'safe' => { 
-    #           'peer' => { 
-    #             'tls' => { 
-    #               'verify' => false
-    #             }
-    #           }
-    #         }
-    #       })
-    #       rendered_template = template.render(properties)
-
-    #       expect(rendered_template).to include('tls_skip_verify = "true"')
-    #     end
-    #   end
-
-    #   context 'safe.peer.tls.self_signed = true' do
-    #     it 'does not include cert and key files' do
-    #       properties.merge!({
-    #         'safe' => { 
-    #           'peer' => { 
-    #             'tls' => { 
-    #               'self_signed' => true
-    #             }
-    #           }
-    #         }
-    #       })
-    #       rendered_template = template.render(properties)
-
-    #       expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/consul/tls/peer/cert.pem"')
-    #       expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/consul/tls/peer/key.pem"')
-    #     end
-    #   end
-    # end
   end
 end

--- a/spec/jobs/consul_spec.rb
+++ b/spec/jobs/consul_spec.rb
@@ -1,0 +1,78 @@
+require 'rspec'
+require 'json'
+require 'bosh/template/test'
+require 'yaml'
+
+describe 'consul' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }
+  let(:job) { release.job('vault') }
+  let(:template) { job.template('config/consul.json') }
+  let(:properties) {{}}
+  let(:links) {
+    [Bosh::Template::Test::Link.new(
+      name: 'vault',
+      instances: [Bosh::Template::Test::LinkInstance.new(address: 'vault.address')]
+    )]
+  }
+
+  context 'config/consul.conf' do
+    context 'with self signed certificates' do
+      it 'creates a default template' do
+        properties.merge!({
+          'safe' => { 
+            'peer' => { 
+              'tls' => { 
+                'verify' => false
+              }
+            }
+          }
+        })
+        rendered_template = JSON.parse(template.render(properties, consumes: links))
+
+        expect(rendered_template['datacenter']).to eq('vault')
+        # expect(rendered_template).to include('tls_cert_file   = "/var/vcap/jobs/consul/tls/peer/cert.pem"')
+        # expect(rendered_template).to include('tls_key_file    = "/var/vcap/jobs/consul/tls/peer/key.pem"')
+        # expect(rendered_template).to include('address = "0.0.0.0:443"')
+        # expect(rendered_template).to include('ui = false')
+        # expect(rendered_template).to include('api_addr = "https://192.168.0.0:443"')
+      end
+    end
+
+    # context 'with tls settings' do
+    #   context 'safe.peer.tls.verify = false' do
+    #     it 'skips ssl verification' do
+    #       properties.merge!({
+    #         'safe' => { 
+    #           'peer' => { 
+    #             'tls' => { 
+    #               'verify' => false
+    #             }
+    #           }
+    #         }
+    #       })
+    #       rendered_template = template.render(properties)
+
+    #       expect(rendered_template).to include('tls_skip_verify = "true"')
+    #     end
+    #   end
+
+    #   context 'safe.peer.tls.self_signed = true' do
+    #     it 'does not include cert and key files' do
+    #       properties.merge!({
+    #         'safe' => { 
+    #           'peer' => { 
+    #             'tls' => { 
+    #               'self_signed' => true
+    #             }
+    #           }
+    #         }
+    #       })
+    #       rendered_template = template.render(properties)
+
+    #       expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/consul/tls/peer/cert.pem"')
+    #       expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/consul/tls/peer/key.pem"')
+    #     end
+    #   end
+    # end
+  end
+end

--- a/spec/jobs/vault_spec.rb
+++ b/spec/jobs/vault_spec.rb
@@ -1,0 +1,63 @@
+require 'rspec'
+require 'json'
+require 'bosh/template/test'
+require 'yaml'
+
+describe 'vault' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }
+  let(:job) { release.job('vault') }
+  let(:template) { job.template('config/vault.config') }
+  let(:properties) {{}}
+
+  context 'config/vault.conf' do
+    context 'with defaults' do
+      it 'creates a default template' do
+        rendered_template = template.render(properties)
+
+        expect(rendered_template).to include('tls_skip_verify = "false"')
+        expect(rendered_template).to include('tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"')
+        expect(rendered_template).to include('tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"')
+        expect(rendered_template).to include('address = "0.0.0.0:443"')
+        expect(rendered_template).to include('ui = false')
+        expect(rendered_template).to include('api_addr = "https://192.168.0.0:443"')
+      end
+    end
+
+    context 'with tls settings' do
+      context 'safe.peer.tls.verify = false' do
+        it 'skips ssl verification' do
+          properties.merge!({
+            'safe' => { 
+              'peer' => { 
+                'tls' => { 
+                  'verify' => false
+                }
+              }
+            }
+          })
+          rendered_template = template.render(properties)
+
+          expect(rendered_template).to include('tls_skip_verify = "true"')
+        end
+      end
+
+      context 'safe.peer.tls.self_signed = true' do
+        it 'does not include cert and key files' do
+          properties.merge!({
+            'safe' => { 
+              'peer' => { 
+                'tls' => { 
+                  'self_signed' => true
+                }
+              }
+            }
+          })
+          rendered_template = template.render(properties)
+
+          expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"')
+          expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"')
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/vault_spec.rb
+++ b/spec/jobs/vault_spec.rb
@@ -40,24 +40,6 @@ describe 'vault' do
           expect(rendered_template).to include('tls_skip_verify = "true"')
         end
       end
-
-      context 'safe.peer.tls.self_signed = true' do
-        it 'does not include cert and key files' do
-          properties.merge!({
-            'safe' => { 
-              'peer' => { 
-                'tls' => { 
-                  'self_signed' => true
-                }
-              }
-            }
-          })
-          rendered_template = template.render(properties)
-
-          expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"')
-          expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"')
-        end
-      end
     end
   end
 end

--- a/spec/jobs/vault_spec.rb
+++ b/spec/jobs/vault_spec.rb
@@ -40,6 +40,24 @@ describe 'vault' do
           expect(rendered_template).to include('tls_skip_verify = "true"')
         end
       end
+
+      context 'safe.peer.tls.use_self_signed_certs = true' do
+        it 'does not include cert and key files' do
+          properties.merge!({
+            'safe' => { 
+              'peer' => { 
+                'tls' => { 
+                  'use_self_signed_certs' => true
+                }
+              }
+            }
+          })
+          rendered_template = template.render(properties)
+
+          expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"')
+          expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If a user uses the release without giving an ssl certificate, the pre-start will generate a new self signed certificate.
If a user provides a non-self-signed certificate then everything will work as usual.
If a user provides a certificate that is self signed, then they need to tell the release by setting "use_self_signed_certificate" to true.