### PR TITLE
add a self signed property

### DIFF
--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -74,6 +74,10 @@ properties:
     description: Verify the TLS certificates presented by the Consul backend
     default: true
 
+  safe.peer.tls.use_self_signed_certs:
+    description: Indicate whether we generate self-signed peer certificates
+    default: false
+
   safe.ui:
     description: If set to true, the Vault UI will be enabled.
     default: false

--- a/jobs/vault/templates/config/vault.conf
+++ b/jobs/vault/templates/config/vault.conf
@@ -8,8 +8,10 @@ backend "consul" {
   tls_min_version = "tls12"
   tls_skip_verify = "<% if p('safe.peer.tls.verify') %>false<% else %>true<% end %>"
   tls_ca_file     = "/var/vcap/jobs/vault/tls/peer/ca.pem"
+  <%- if ! p('safe.peer.tls.use_self_signed_certs') -%>
   tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"
   tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"
+  <%- end -%>
 }
 
 listener "tcp" {

--- a/spec/jobs/vault_spec.rb
+++ b/spec/jobs/vault_spec.rb
@@ -40,6 +40,24 @@ describe 'vault' do
           expect(rendered_template).to include('tls_skip_verify = "true"')
         end
       end
+
+      context 'safe.peer.tls.use_self_signed_certs = true' do
+        it 'does not include cert and key files' do
+          properties.merge!({
+            'safe' => { 
+              'peer' => { 
+                'tls' => { 
+                  'use_self_signed_certs' => true
+                }
+              }
+            }
+          })
+          rendered_template = template.render(properties)
+
+          expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"')
+          expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If a user uses the release without giving an ssl certificate, the pre-start will generate a new self signed certificate.
If a user provides a non-self-signed certificate then everything will work as usual.
If a user provides a certificate that is self signed, then they need to tell the release by setting "use_self_signed_certificate" to true.