### PR TITLE
safe-boshrelease upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'bosh-template'
+  gem 'rspec'
+  gem 'rspec-its'
+  gem 'guard-rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,69 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bosh-template (2.3.0)
+      semi_semantic (~> 1.2.0)
+    coderay (1.1.2)
+    diff-lcs (1.5.0)
+    ffi (1.15.5)
+    formatador (0.3.0)
+    guard (2.18.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    lumberjack (1.2.8)
+    method_source (1.0.0)
+    nenv (0.3.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rb-fsevent (0.11.1)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    semi_semantic (1.2.0)
+    shellany (0.0.1)
+    thor (1.2.1)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  bosh-template
+  guard-rspec
+  rspec
+  rspec-its
+
+BUNDLED WITH
+   2.2.33

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ happy, great.  I wanted something simpler and more opinionated.
 ## How Does This Relate To The `safe` CLI for Vault?
 
 [safe][safe] has some built-in support for this particular BOSH
-release, by way of a thing called `strongbox`.  Primarily, the
+release, by way of a thing called [`strongbox`][strongbox].  Primarily, the
 extra handy `safe unseal` and `safe seal` commands work _only_
 with this BOSH release.
 
@@ -108,3 +108,4 @@ start up properly, and the deployment as a whole will fail.
 
 [safe]: https://github.com/starkandwayne/safe
 [sb]:   https://github.com/cloudfoundry-community/vault-broker
+[strongbox]: https://github.com/jhunt/go-strongbox

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,6 +2,10 @@ consul/consul_0.7.0_linux_amd64.zip:
   size: 6470848
   object_id: 542a845e-a01e-4742-a01a-a6be315847d2
   sha: 32d5f51c35b75216cf73cabe0329239355dc4266
+consul/consul_1.11.3_linux_amd64.zip:
+  size: 38363933
+  object_id: cda2b610-97f9-423e-74f1-999943f2afb4
+  sha: sha256:782b8bc0bc94e6d9f0dceb3272fca0e629d8d9d0f039b1a7749e3218f6f2424c
 strongbox/strongbox:
   size: 6420275
   object_id: bcc9bf2a-e374-46a8-7052-f5553c9187b6

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -7,9 +7,9 @@ consul/consul_1.11.3_linux_amd64.zip:
   object_id: cda2b610-97f9-423e-74f1-999943f2afb4
   sha: sha256:782b8bc0bc94e6d9f0dceb3272fca0e629d8d9d0f039b1a7749e3218f6f2424c
 strongbox/strongbox:
-  size: 6420275
-  object_id: bcc9bf2a-e374-46a8-7052-f5553c9187b6
-  sha: sha256:05fc2370a135795b88e0e77d5348d966367287b84f436cc3b1317d54512dbed0
+  size: 7321376
+  object_id: 1042b8ac-b166-4131-5174-c1948614449f
+  sha: sha256:fa3eab0a9ac6949d070501150d75f98be59dda6f632cfcc9ec7a0bc858b4c2b3
 vault-broker/vault-broker:
   size: 7100965
   object_id: be179dcc-9a0f-415b-4710-287218c2decd

--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -11,8 +11,8 @@ templates:
   bin/consul: bin/consul
   bin/strongbox: bin/strongbox
 
-  config/vault.conf: config/vault.conf
-  config/consul.conf: config/consul.conf
+  config/vault.conf: config/vault.config
+  config/consul.conf: config/consul.json
 
   tls/vault/cert.pem: tls/vault/cert.pem
   tls/vault/key.pem: tls/vault/key.pem

--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -73,6 +73,10 @@ properties:
     description: Verify the TLS certificates presented by the Consul backend
     default: true
 
+  safe.peer.tls.self_signed:
+    description: Indicate whether the certificates are self signed
+    default: false
+
   safe.ui:
     description: If set to true, the Vault UI will be enabled.
     default: false

--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -10,6 +10,7 @@ templates:
   bin/vault: bin/vault
   bin/consul: bin/consul
   bin/strongbox: bin/strongbox
+  bin/pre-start: bin/pre-start
 
   config/vault.conf: config/vault.config
   config/consul.conf: config/consul.json
@@ -72,10 +73,6 @@ properties:
   safe.peer.tls.verify:
     description: Verify the TLS certificates presented by the Consul backend
     default: true
-
-  safe.peer.tls.self_signed:
-    description: Indicate whether the certificates are self signed
-    default: false
 
   safe.ui:
     description: If set to true, the Vault UI will be enabled.

--- a/jobs/vault/templates/bin/consul
+++ b/jobs/vault/templates/bin/consul
@@ -38,7 +38,7 @@ case $1 in
     GOMAXPROCS=2 \
     chpst -u vcap:vcap \
       /var/vcap/packages/consul/bin/consul agent \
-         -config-file ${JOB_DIR}/config/consul.conf \
+         -config-file ${JOB_DIR}/config/consul.json \
          -data-dir ${DAT_DIR}/consul \
          -pid-file $PIDFILE
     ;;

--- a/jobs/vault/templates/bin/consul
+++ b/jobs/vault/templates/bin/consul
@@ -45,6 +45,7 @@ case $1 in
 
   stop)
     /var/vcap/packages/consul/bin/consul leave
+    # kill -INT $(cat $PIDFILE)
     ;;
 
   reload)

--- a/jobs/vault/templates/bin/consul
+++ b/jobs/vault/templates/bin/consul
@@ -27,13 +27,6 @@ case $1 in
     mkdir -p ${DAT_DIR}/consul
     chown vcap:vcap ${DAT_DIR}/consul
 
-    # check for certificates
-    if ! (openssl x509 -noout -in ${JOB_DIR}/tls/peer/ca.pem   && \
-          openssl x509 -noout -in ${JOB_DIR}/tls/peer/cert.pem && \
-          openssl rsa  -noout -in ${JOB_DIR}/tls/peer/key.pem); then
-      /var/vcap/packages/certifier/bin/certify ${JOB_DIR}/tls/peer/
-    fi
-
     # run consul
     GOMAXPROCS=2 \
     chpst -u vcap:vcap \

--- a/jobs/vault/templates/bin/pre-start
+++ b/jobs/vault/templates/bin/pre-start
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu
+
+# If are no supplied certificates generate self signed certificates
+
+VAULT_JOB_DIR=/var/vcap/jobs/vault
+CONSUL_JOB_DIR=/var/vcap/jobs/consul
+
+ # check for vault certificates
+if ! (openssl x509 -noout -in ${VAULT_JOB_DIR}/tls/vault/cert.pem &&
+      openssl rsa  -noout -in ${VAULT_JOB_DIR}/tls/vault/key.pem); then
+  /var/vcap/packages/certifier/bin/certify ${VAULT_JOB_DIR}/tls/vault/
+fi
+
+# check for consul certificates
+if ! (openssl x509 -noout -in ${CONSUL_JOB_DIR}/tls/peer/ca.pem   && \
+      openssl x509 -noout -in ${CONSUL_JOB_DIR}/tls/peer/cert.pem && \
+      openssl rsa  -noout -in ${CONSUL_JOB_DIR}/tls/peer/key.pem); then
+  /var/vcap/packages/certifier/bin/certify ${CONSUL_JOB_DIR}/tls/peer/
+fi

--- a/jobs/vault/templates/bin/vault
+++ b/jobs/vault/templates/bin/vault
@@ -18,12 +18,6 @@ case $1 in
       rm -f $PIDFILE
     fi
 
-    # check for certificates
-    if ! (openssl x509 -noout -in ${JOB_DIR}/tls/vault/cert.pem &&
-          openssl rsa  -noout -in ${JOB_DIR}/tls/vault/key.pem); then
-      /var/vcap/packages/certifier/bin/certify ${JOB_DIR}/tls/vault/
-    fi
-
     bin=$(readlink -nf /var/vcap/packages/vault/bin/vault)
     setcap cap_ipc_lock=+ep         $bin
     setcap cap_net_bind_service=+ep $bin

--- a/jobs/vault/templates/bin/vault
+++ b/jobs/vault/templates/bin/vault
@@ -30,16 +30,16 @@ case $1 in
 
     if chpst -u vcap:vcap /var/vcap/packages/vault/bin/canimlock; then
       sed -i -e 's/^disable_mlock/#disable_mlock/' \
-        $JOB_DIR/config/vault.conf
+        $JOB_DIR/config/vault.config
     else
       sed -i -e 's/^#disable_mlock/disable_mlock/' \
-        $JOB_DIR/config/vault.conf
+        $JOB_DIR/config/vault.config
     fi
 
     echo $$ > $PIDFILE
     exec chpst -u vcap:vcap \
       /var/vcap/packages/vault/bin/vault server \
-        -config=${JOB_DIR}/config/vault.conf
+        -config=${JOB_DIR}/config/vault.config
     ;;
 
   stop)

--- a/jobs/vault/templates/config/vault.conf
+++ b/jobs/vault/templates/config/vault.conf
@@ -8,10 +8,8 @@ backend "consul" {
   tls_min_version = "tls12"
   tls_skip_verify = "<% if p('safe.peer.tls.verify') %>false<% else %>true<% end %>"
   tls_ca_file     = "/var/vcap/jobs/vault/tls/peer/ca.pem"
-  <%- if ! p('safe.peer.tls.self_signed') -%>
   tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"
   tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"
-  <%- end -%>
 }
 
 listener "tcp" {

--- a/jobs/vault/templates/config/vault.conf
+++ b/jobs/vault/templates/config/vault.conf
@@ -8,8 +8,10 @@ backend "consul" {
   tls_min_version = "tls12"
   tls_skip_verify = "<% if p('safe.peer.tls.verify') %>false<% else %>true<% end %>"
   tls_ca_file     = "/var/vcap/jobs/vault/tls/peer/ca.pem"
+  <%- if ! p('safe.peer.tls.self_signed') -%>
   tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"
   tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"
+  <%- end -%>
 }
 
 listener "tcp" {

--- a/packages/consul/packaging
+++ b/packages/consul/packaging
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-VERSION=0.7.0
+VERSION=1.11.3
 # from https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_linux_amd64.zip
 cd consul
 unzip consul_${VERSION}_linux_amd64.zip

--- a/packages/consul/spec
+++ b/packages/consul/spec
@@ -2,4 +2,4 @@
 name: consul
 dependencies: []
 files:
-  - consul/consul_0.7.0_linux_amd64.zip
+  - consul/consul_1.11.3_linux_amd64.zip

--- a/packages/strongbox/packaging
+++ b/packages/strongbox/packaging
@@ -1,6 +1,8 @@
 #!/bin/bashj
 set -eu
 
+# https://github.com/jhunt/go-strongbox
+#
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 cp strongbox/strongbox ${BOSH_INSTALL_TARGET}/bin
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/strongbox

--- a/packages/vault/packaging
+++ b/packages/vault/packaging
@@ -8,7 +8,12 @@ pushd mlock
   cp maybe $BOSH_INSTALL_TARGET/bin/canimlock
 popd
 
+# blob comes from https://releases.hashicorp.com/vault/ 
+# source comes from https://github.com/hashicorp/vault
+
+BLOB_VAULT_VERSION=1.9.3
+
 pushd vault
-  unzip vault_1.4.0_linux_amd64.zip
+  unzip vault_${BLOB_VAULT_VERSION}_linux_amd64.zip
   cp -a vault $BOSH_INSTALL_TARGET/bin
 popd

--- a/packages/vault/spec
+++ b/packages/vault/spec
@@ -1,5 +1,5 @@
 ---
 name: vault
 files:
-  - vault/vault_1.4.0_linux_amd64.zip
+  - vault/vault_1.9.3_linux_amd64.zip
   - mlock/maybe.c

--- a/spec/jobs/consul_spec.rb
+++ b/spec/jobs/consul_spec.rb
@@ -30,49 +30,7 @@ describe 'consul' do
         rendered_template = JSON.parse(template.render(properties, consumes: links))
 
         expect(rendered_template['datacenter']).to eq('vault')
-        # expect(rendered_template).to include('tls_cert_file   = "/var/vcap/jobs/consul/tls/peer/cert.pem"')
-        # expect(rendered_template).to include('tls_key_file    = "/var/vcap/jobs/consul/tls/peer/key.pem"')
-        # expect(rendered_template).to include('address = "0.0.0.0:443"')
-        # expect(rendered_template).to include('ui = false')
-        # expect(rendered_template).to include('api_addr = "https://192.168.0.0:443"')
       end
     end
-
-    # context 'with tls settings' do
-    #   context 'safe.peer.tls.verify = false' do
-    #     it 'skips ssl verification' do
-    #       properties.merge!({
-    #         'safe' => { 
-    #           'peer' => { 
-    #             'tls' => { 
-    #               'verify' => false
-    #             }
-    #           }
-    #         }
-    #       })
-    #       rendered_template = template.render(properties)
-
-    #       expect(rendered_template).to include('tls_skip_verify = "true"')
-    #     end
-    #   end
-
-    #   context 'safe.peer.tls.self_signed = true' do
-    #     it 'does not include cert and key files' do
-    #       properties.merge!({
-    #         'safe' => { 
-    #           'peer' => { 
-    #             'tls' => { 
-    #               'self_signed' => true
-    #             }
-    #           }
-    #         }
-    #       })
-    #       rendered_template = template.render(properties)
-
-    #       expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/consul/tls/peer/cert.pem"')
-    #       expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/consul/tls/peer/key.pem"')
-    #     end
-    #   end
-    # end
   end
 end

--- a/spec/jobs/consul_spec.rb
+++ b/spec/jobs/consul_spec.rb
@@ -1,0 +1,78 @@
+require 'rspec'
+require 'json'
+require 'bosh/template/test'
+require 'yaml'
+
+describe 'consul' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }
+  let(:job) { release.job('vault') }
+  let(:template) { job.template('config/consul.json') }
+  let(:properties) {{}}
+  let(:links) {
+    [Bosh::Template::Test::Link.new(
+      name: 'vault',
+      instances: [Bosh::Template::Test::LinkInstance.new(address: 'vault.address')]
+    )]
+  }
+
+  context 'config/consul.conf' do
+    context 'with self signed certificates' do
+      it 'creates a default template' do
+        properties.merge!({
+          'safe' => { 
+            'peer' => { 
+              'tls' => { 
+                'verify' => false
+              }
+            }
+          }
+        })
+        rendered_template = JSON.parse(template.render(properties, consumes: links))
+
+        expect(rendered_template['datacenter']).to eq('vault')
+        # expect(rendered_template).to include('tls_cert_file   = "/var/vcap/jobs/consul/tls/peer/cert.pem"')
+        # expect(rendered_template).to include('tls_key_file    = "/var/vcap/jobs/consul/tls/peer/key.pem"')
+        # expect(rendered_template).to include('address = "0.0.0.0:443"')
+        # expect(rendered_template).to include('ui = false')
+        # expect(rendered_template).to include('api_addr = "https://192.168.0.0:443"')
+      end
+    end
+
+    # context 'with tls settings' do
+    #   context 'safe.peer.tls.verify = false' do
+    #     it 'skips ssl verification' do
+    #       properties.merge!({
+    #         'safe' => { 
+    #           'peer' => { 
+    #             'tls' => { 
+    #               'verify' => false
+    #             }
+    #           }
+    #         }
+    #       })
+    #       rendered_template = template.render(properties)
+
+    #       expect(rendered_template).to include('tls_skip_verify = "true"')
+    #     end
+    #   end
+
+    #   context 'safe.peer.tls.self_signed = true' do
+    #     it 'does not include cert and key files' do
+    #       properties.merge!({
+    #         'safe' => { 
+    #           'peer' => { 
+    #             'tls' => { 
+    #               'self_signed' => true
+    #             }
+    #           }
+    #         }
+    #       })
+    #       rendered_template = template.render(properties)
+
+    #       expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/consul/tls/peer/cert.pem"')
+    #       expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/consul/tls/peer/key.pem"')
+    #     end
+    #   end
+    # end
+  end
+end

--- a/spec/jobs/vault_spec.rb
+++ b/spec/jobs/vault_spec.rb
@@ -1,0 +1,63 @@
+require 'rspec'
+require 'json'
+require 'bosh/template/test'
+require 'yaml'
+
+describe 'vault' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }
+  let(:job) { release.job('vault') }
+  let(:template) { job.template('config/vault.config') }
+  let(:properties) {{}}
+
+  context 'config/vault.conf' do
+    context 'with defaults' do
+      it 'creates a default template' do
+        rendered_template = template.render(properties)
+
+        expect(rendered_template).to include('tls_skip_verify = "false"')
+        expect(rendered_template).to include('tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"')
+        expect(rendered_template).to include('tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"')
+        expect(rendered_template).to include('address = "0.0.0.0:443"')
+        expect(rendered_template).to include('ui = false')
+        expect(rendered_template).to include('api_addr = "https://192.168.0.0:443"')
+      end
+    end
+
+    context 'with tls settings' do
+      context 'safe.peer.tls.verify = false' do
+        it 'skips ssl verification' do
+          properties.merge!({
+            'safe' => { 
+              'peer' => { 
+                'tls' => { 
+                  'verify' => false
+                }
+              }
+            }
+          })
+          rendered_template = template.render(properties)
+
+          expect(rendered_template).to include('tls_skip_verify = "true"')
+        end
+      end
+
+      context 'safe.peer.tls.self_signed = true' do
+        it 'does not include cert and key files' do
+          properties.merge!({
+            'safe' => { 
+              'peer' => { 
+                'tls' => { 
+                  'self_signed' => true
+                }
+              }
+            }
+          })
+          rendered_template = template.render(properties)
+
+          expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"')
+          expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"')
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/vault_spec.rb
+++ b/spec/jobs/vault_spec.rb
@@ -40,24 +40,6 @@ describe 'vault' do
           expect(rendered_template).to include('tls_skip_verify = "true"')
         end
       end
-
-      context 'safe.peer.tls.self_signed = true' do
-        it 'does not include cert and key files' do
-          properties.merge!({
-            'safe' => { 
-              'peer' => { 
-                'tls' => { 
-                  'self_signed' => true
-                }
-              }
-            }
-          })
-          rendered_template = template.render(properties)
-
-          expect(rendered_template).not_to include('tls_cert_file   = "/var/vcap/jobs/vault/tls/peer/cert.pem"')
-          expect(rendered_template).not_to include('tls_key_file    = "/var/vcap/jobs/vault/tls/peer/key.pem"')
-        end
-      end
     end
   end
 end

--- a/src/certifier/certify
+++ b/src/certifier/certify
@@ -112,13 +112,19 @@ openssl req \
   -config ${WORKDIR}/openssl.conf </dev/null
 
 echo Self-signing the CA certificate request
+rm -f ${WORKDIR}/ca/cert.pem.txt 
 openssl ca \
   -create_serial -batch -selfsign \
-  -extensions ca_cert \
+  -notext -extensions ca_cert \
   -in ${WORKDIR}/ca/req.pem \
   -out ${WORKDIR}/ca/cert.pem \
   -keyfile ${WORKDIR}/ca/key.pem \
   -config ${WORKDIR}/openssl.conf </dev/null
+
+openssl x509 \
+  -text \
+  -in ${WORKDIR}/ca/cert.pem \
+  -noout > ${WORKDIR}/ca/cert.pem.txt 2>&1 </dev/null
 
 echo Generating a new RSA private key
 openssl genrsa \
@@ -134,8 +140,10 @@ openssl req \
   -config ${WORKDIR}/openssl.conf </dev/null
 
 echo Signing the certificate request with the CA signing key
+rm -f ${WORKDIR}/cert.pem.txt 
 openssl ca \
   -batch \
+  -notext \
   -extensions issued_cert \
   -in ${WORKDIR}/req.pem \
   -out ${WORKDIR}/cert.pem \
@@ -143,8 +151,15 @@ openssl ca \
   -keyfile ${WORKDIR}/ca/key.pem \
   -config ${WORKDIR}/openssl.conf </dev/null
 
+openssl x509 \
+  -text \
+  -in ${WORKDIR}/cert.pem \
+  -noout >${WORKDIR}/cert.pem.txt 2>&1 </dev/null
+
 cd ${1:-$PWD}
 echo Installing the CA certificate, private key, and certificate in ${PWD}
-cp ${WORKDIR}/ca/cert.pem  ca.pem
-cp ${WORKDIR}/key.pem      key.pem
-cp ${WORKDIR}/cert.pem     cert.pem
+cp ${WORKDIR}/ca/cert.pem.txt  ca.pem.txt
+cp ${WORKDIR}/ca/cert.pem      ca.pem
+cp ${WORKDIR}/key.pem          key.pem
+cp ${WORKDIR}/cert.pem.txt     cert.pem.txt
+cp ${WORKDIR}/cert.pem         cert.pem


### PR DESCRIPTION
1. Upgraded strongbox to the latest release of go
2. Upgraded consul to a later release 1.11.3
3. Upgraded vault to 1.9.3
4. Consul has an issue with self-signed certificates and we added a temporary workaround by adding the spec variable safe.peer.tls.use_self_signed_certs property
 5. Added rspecs for the manifest testing
 6. Moved unsigned cert generation to a pre-start script
 7. The self signed certs included text that was not part of the rfc5280.